### PR TITLE
Fix typo in openssl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ salt: "$SALT"
 admin_password_command: "$ADMIN_PASSWORD_COMMAND"
 ```
 
-`admin_password_command` should be formulated to print the desired password to `stdout`, eg `openssl -base64 32`
+`admin_password_command` should be formulated to print the desired password to `stdout`, eg `openssl rand -base64 32`


### PR DESCRIPTION
typo in openssl command to generate password